### PR TITLE
Remove -fstack-protector-strong from Makefile

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -176,7 +176,7 @@ EXTRA_CFLAGS += $(shell [ -f $(KSRC)/include/linux/modversions.h ] && \
 EXTRA_CFLAGS += -fno-PIC
 
 # security enhancing flags
-EXTRA_CFLAGS += -fstack-protector-strong -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv
+EXTRA_CFLAGS += -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv
 
 EXTRA_CFLAGS += $(CFLAGS_EXTRA)
 


### PR DESCRIPTION
Build igb_avb driver without stack-protector-strong.

Check this configuration on branch 4.14. 4.14.212 kernel version